### PR TITLE
Trims 6 more characters off front of input.

### DIFF
--- a/aic.sh
+++ b/aic.sh
@@ -367,7 +367,7 @@ INPUT="$(jp2a --term-fit --color --html $OPT_FILL "$FILE_IMAGE")"
 export LINES="$OLD_LINES"
 
 # Remove HTML tags from beginning and end
-INPUT="${INPUT:449}"
+INPUT="${INPUT:455}"
 INPUT="${INPUT::-29}"
 INPUT="${INPUT::-5}" # <br/>
 


### PR DESCRIPTION
When I tried running the script I got a somewhat cryptic error message: `syntax error (invalid integer constant (error token is "16#"))`. When I looked into it, the root issue was that `INPUT` still had a leading `<pre> ` after the trimming on lines 370–372. This patch takes off an extra 6 characters to remove the `<pre> `. Everything seems to be working fine after that.
