### PR TITLE
feat(container): add Containerfile and examples to README

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,3 +21,5 @@ WORKDIR /usr/src/app
 RUN git remote add dylan-stark https://github.com/dylan-stark/aic-bash.git && \
     git fetch dylan-stark && \
     git rebase dylan-stark/extra-trim-on-input
+
+CMD [ "./aic.sh", "--quality", "medium", "--ratio", "120" ]

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,23 @@
+FROM docker.io/library/ubuntu:noble
+
+RUN apt update && \
+    apt install -y \
+        coreutils \
+        curl \
+        git \
+        imagemagick \
+        jq \
+        jp2a \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /usr/src/app && chown 1000:1000 /usr/src/app
+
+USER 1000:1000
+RUN git clone --depth 1 https://github.com/art-institute-of-chicago/aic-bash /usr/src/app
+
+WORKDIR /usr/src/app
+# Apply the patch from https://github.com/art-institute-of-chicago/aic-bash/pull/7
+RUN git remote add dylan-stark https://github.com/dylan-stark/aic-bash.git && \
+    git fetch dylan-stark && \
+    git rebase dylan-stark/extra-trim-on-input

--- a/README.md
+++ b/README.md
@@ -228,11 +228,16 @@ Build it with:
 
 Run it with:
 
-    podman run --rm -it aic-bash
+    podman run --rm -t aic-bash
+
+Enter a shell with:
+
+    podman run --rm -t aic-bash
 
 You can use it to run `aic.sh` commands directly:
 
-    podman run --rm aic-bash ./aic.sh --quality medium --ratio 120
+    podman run --rm -t aic-bash ./aic.sh --quality medium
+    podman run --rm -t aic-bash ./aic.sh --quality medium --ratio 120
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Art Institute of Chicago (AIC) offers all of its public data via a centraliz
 
 ## Requirements
 
-Please read this section in its entirety before installing anything. 
+Please read this section in its entirety before installing anything.
 
  * A terminal with [truecolor (24bit) support](https://gist.github.com/XVilka/8346728) (recommendations below)
  * [Bash v4.2](https://www.tldp.org/LDP/abs/html/bashver4.html#AEN21220) (Feb. 2011) or higher

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ After running this query once, it will cache the results. If you run it again wi
 If you use `--cache` without specifying `[num]`, it'll default to 3600 seconds, i.e. 1 hour.
 
 
+## Run in a container
+
+This repository provides a `Containerfile` to build a Container image, which includes all dependencies.
+
+Build it with:
+
+    podman build -t art-institute-of-chicago/aic-bash .
+
+Run it with:
+
+    podman run --rm -it aic-bash
+
+You can use it to run `aic.sh` commands directly:
+
+    podman run --rm aic-bash ./aic.sh --quality medium --ratio 120
+
+
 ## Contributing
 
 We encourage your contributions. Please fork this repository and make your changes in a separate branch. To better understand how we organize our code, please review our [version control guidelines](https://docs.google.com/document/d/1B-27HBUc6LDYHwvxp3ILUcPTo67VFIGwo5Hiq4J9Jjw).


### PR DESCRIPTION
This brings a `Containerfile`, which helps in collecting and documenting the expected runtime dependencies.

It is built with Podman, but can be easily applied to Docker as well.

Closes #8 